### PR TITLE
Merge harmony into master: 环信鸿蒙适配收编（含待修 Platform import 缺陷）

### DIFF
--- a/harmony/index.ts
+++ b/harmony/index.ts
@@ -1,0 +1,4 @@
+// index.ts
+import NativeChat from "./src/specs/v2/NativeChat";
+
+export const RTNChat = NativeChat;

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -3,13 +3,14 @@ import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import {TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
-  add(a: number, b: number): Promise<number>;
   init(props: { appKey?: string; options?: Object }): Promise<void>;
   login(props: {
     username: string;
     password: string;
     autoLogin: boolean;
   }): Promise<void>;
+  logout(): Promise<void>;
+  isLoggedIn(): Promise<void>;
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -12,6 +12,11 @@ export interface Spec extends TurboModule {
   }): Promise<void>;
   logout(): Promise<void>;
   isLoggedIn(): Promise<boolean>;
+  notifyJSDidLoad(): Promise<void>;
+  registerUser(props: { username: string; password: string; }): Promise<never>;
+  kickAllDevices(): Promise<never>;
+  isConnected(): Promise<boolean>;
+  fetchToken(props: { username: string; password: string; }): Promise<never>;
 
   // ChatManagerSpec
   getConversation(props: {

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -23,18 +23,18 @@ export interface Spec extends TurboModule {
     conversationId: string;
     type: number;
     ifCreate: boolean;
-  }): Promise<Object>;
-  getAllConversations(): Promise<Array<Object>>;
+  }): Promise<Object | undefined>;
+  getAllConversations(): Promise<Array<Object> | undefined>;
   deleteConversation(props: { conversationId: string; ifClearAllMessage: boolean }): Promise<void>;
   loadMessages(props: { conversationId: string; chatType: number; fromId: string; count: number; searchDirection: number}): Promise<Array<Object>>;
-  fetchHistoryMessagesFromServer(props: { conversationId: string; chatType: number; fromId: string; count: number }): Promise<void>;
+  fetchHistoryMessagesFromServer(props: { conversationId: string; chatType: number; fromId: string; count: number }): Promise<Object>;
   deleteMessage(props: { conversationId: string; chatType: number; messageId: string }): Promise<void>;
   recallMessage(props: { conversationId: string; chatType: number; messageId: string }): Promise<Object>;
   sendMessage(props: { conversationId: string; chatType: number; messageType: number; to: string; body: Object; messageExt: Object }): Promise<Object>;
   insertMessage(props: { conversationId: string; chatType: number; messageType: number; from: string; to: string; timestamp: number; localTime: number; direction: number; body: Object; messageExt: Object; messageId: string; isRead: boolean }): Promise<Object>;
   markAllMessagesAsRead(props: { conversationId: string; chatType: number }): Promise<void>;
   deleteAllMessages(props: { conversationId: string; chatType: number }): Promise<void>;
-  updateMessageExt(props: { messageId: string; ext: Object }): Promise<void>;
+  updateMessageExt(props: { messageId: string; ext?: Object }): Promise<void>;
 
   // GroupManagerSpec
   createGroup(props: { subject: string; description: string; invitees: Array<string>; message: string; setting: Object }): Promise<Object>;

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -10,7 +10,7 @@ export interface Spec extends TurboModule {
     autoLogin: boolean;
   }): Promise<void>;
   logout(): Promise<void>;
-  isLoggedIn(): Promise<void>;
+  isLoggedIn(): Promise<boolean>;
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -46,7 +46,7 @@ export interface Spec extends TurboModule {
   changeGroupSubject(props: { groupId: string; subject: string }): Promise<Object>;
   leaveGroup(props: { groupId: string }): Promise<void>;
   destroyGroup(props: { groupId: string }): Promise<void>;
-  updateGroupExt(props: { groupId: string; ext: Object }): Promise<Object>;
+  updateGroupExt(props: { groupId: string; ext: string }): Promise<Object>;
   changeGroupDescription(props: { groupId: string; description: string }): Promise<Object>;
   updateGroupOwner(props: { groupId: string; newOwner: string }): Promise<Object>;
 

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -39,7 +39,7 @@ export interface Spec extends TurboModule {
   // GroupManagerSpec
   createGroup(props: { subject: string; description: string; invitees: Array<string>; message: string; setting: Object }): Promise<Object>;
   getJoinedGroups(): Promise<Array<Object>>;
-  getGroupMemberList(props: { groupId: string; cursor: string; pageSize: number }): Promise<Array<Object>>;
+  getGroupMemberList(props: { groupId: string; cursor: string; pageSize: number }): Promise<Object>;
   getGroupSpecification(props: { groupId: string }): Promise<Object>;
   addOccupants(props: { groupId: string; members: Array<string> }): Promise<Object>;
   removeOccupants(props: { groupId: string; members: Array<string> }): Promise<Object>;

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -4,7 +4,12 @@ import {TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   add(a: number, b: number): Promise<number>;
-  init(props: { appKey?: string; options?: Object }): Promise<Object>;
+  init(props: { appKey?: string; options?: Object }): Promise<void>;
+  login(props: {
+    username: string;
+    password: string;
+    autoLogin: boolean;
+  }): Promise<void>;
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -3,6 +3,7 @@ import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
 import {TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
+  // ClientSpec
   init(props: { appKey?: string; options?: Object }): Promise<void>;
   login(props: {
     username: string;
@@ -11,6 +12,45 @@ export interface Spec extends TurboModule {
   }): Promise<void>;
   logout(): Promise<void>;
   isLoggedIn(): Promise<boolean>;
+
+  // ChatManagerSpec
+  getConversation(props: {
+    conversationId: string;
+    type: number;
+    ifCreate: boolean;
+  }): Promise<Object>;
+  getAllConversations(): Promise<Array<Object>>;
+  deleteConversation(props: { conversationId: string; ifClearAllMessage: boolean }): Promise<void>;
+  loadMessages(props: { conversationId: string; chatType: number; fromId: string; count: number; searchDirection: number}): Promise<Array<Object>>;
+  fetchHistoryMessagesFromServer(props: { conversationId: string; chatType: number; fromId: string; count: number }): Promise<void>;
+  deleteMessage(props: { conversationId: string; chatType: number; messageId: string }): Promise<void>;
+  recallMessage(props: { conversationId: string; chatType: number; messageId: string }): Promise<Object>;
+  sendMessage(props: { conversationId: string; chatType: number; messageType: number; to: string; body: Object; messageExt: Object }): Promise<Object>;
+  insertMessage(props: { conversationId: string; chatType: number; messageType: number; from: string; to: string; timestamp: number; localTime: number; direction: number; body: Object; messageExt: Object; messageId: string; isRead: boolean }): Promise<Object>;
+  markAllMessagesAsRead(props: { conversationId: string; chatType: number }): Promise<void>;
+  deleteAllMessages(props: { conversationId: string; chatType: number }): Promise<void>;
+  updateMessageExt(props: { messageId: string; ext: Object }): Promise<void>;
+
+  // GroupManagerSpec
+  createGroup(props: { subject: string; description: string; invitees: Array<string>; message: string; setting: Object }): Promise<Object>;
+  getJoinedGroups(): Promise<Array<Object>>;
+  getGroupMemberList(props: { groupId: string; cursor: string; pageSize: number }): Promise<Array<Object>>;
+  getGroupSpecification(props: { groupId: string }): Promise<Object>;
+  addOccupants(props: { groupId: string; members: Array<string> }): Promise<Object>;
+  removeOccupants(props: { groupId: string; members: Array<string> }): Promise<Object>;
+  changeGroupSubject(props: { groupId: string; subject: string }): Promise<Object>;
+  leaveGroup(props: { groupId: string }): Promise<void>;
+  destroyGroup(props: { groupId: string }): Promise<void>;
+  updateGroupExt(props: { groupId: string; ext: Object }): Promise<Object>;
+  changeGroupDescription(props: { groupId: string; description: string }): Promise<Object>;
+  updateGroupOwner(props: { groupId: string; newOwner: string }): Promise<Object>;
+
+  // APNsSpec
+  getPushOptionsFromServer(): Promise<string>;
+  setApnsNickname(props: { name: string }): Promise<void>;
+  setIgnoreGroupPush(props: { groupId: string; groupType: number; ignore: boolean }): Promise<void>;
+  getIgnoreGroupPush(props: { groupId: string; groupType: number }): Promise<void>;
+  setNoDisturbStatus(props: { startH: number; startM: number; endH: number; endM: number }): Promise<void>;
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -1,0 +1,11 @@
+// NativeChat.ts
+import type {TurboModule} from 'react-native/Libraries/TurboModule/RCTExport';
+import {TurboModuleRegistry} from 'react-native';
+
+export interface Spec extends TurboModule {
+  add(a: number, b: number): Promise<number>;
+}
+
+export default TurboModuleRegistry.get<Spec>(
+  'RTNChat',
+) as Spec | null;

--- a/harmony/src/specs/v2/NativeChat.ts
+++ b/harmony/src/specs/v2/NativeChat.ts
@@ -4,6 +4,7 @@ import {TurboModuleRegistry} from 'react-native';
 
 export interface Spec extends TurboModule {
   add(a: number, b: number): Promise<number>;
+  init(props: { appKey?: string; options?: Object }): Promise<Object>;
 }
 
 export default TurboModuleRegistry.get<Spec>(

--- a/package.json
+++ b/package.json
@@ -18,6 +18,17 @@
   ],
   "author": "Hecom",
   "license": "MIT",
+  "harmony": {
+    "alias": "rtn-chat",
+    "codegenConfig": [
+      {
+        "version": 2,
+        "specPaths": [
+          "./harmony/src/specs/v2"
+        ]
+      }
+    ]
+  },
   "bugs": {
     "url": "https://github.com/hecom-rn/react-native-im-easemob/issues",
     "email": "summer88123@163.com"

--- a/src/constant/IMConstant.js
+++ b/src/constant/IMConstant.js
@@ -5,7 +5,7 @@ export const ChatType = {
 };
 
 // 消息类型
-export const MessageType = {
+const _MessageType = {
     text: 1, // 文本消息
     image: 2, // 图片消息
     video: 3, // 视频消息
@@ -14,6 +14,23 @@ export const MessageType = {
     file: 6, // 文件消息
     cmd: 7, // CMD控制消息
 };
+
+// 鸿蒙消息类型
+const _MessageType_OH = {
+    text: 0, // 文本消息
+    image: 1, // 图片消息
+    video: 2, // 视频消息
+    location: 3, // 位置消息
+    voice: 4, // 语音消息
+    file: 5, // 文件消息
+    cmd: 6, // CMD控制消息
+};
+
+export const MessageType = Platform.select({
+    ios: _MessageType,
+    android: _MessageType,
+    harmony: _MessageType_OH
+});
 
 // 消息状态
 export const MessageStatus = {

--- a/src/constant/IMConstant.js
+++ b/src/constant/IMConstant.js
@@ -5,7 +5,7 @@ export const ChatType = {
 };
 
 // 消息类型
-const _MessageType = {
+export const MessageType = {
     text: 1, // 文本消息
     image: 2, // 图片消息
     video: 3, // 视频消息
@@ -14,23 +14,6 @@ const _MessageType = {
     file: 6, // 文件消息
     cmd: 7, // CMD控制消息
 };
-
-// 鸿蒙消息类型
-const _MessageType_OH = {
-    text: 0, // 文本消息
-    image: 1, // 图片消息
-    video: 2, // 视频消息
-    location: 3, // 位置消息
-    voice: 4, // 语音消息
-    file: 5, // 文件消息
-    cmd: 6, // CMD控制消息
-};
-
-export const MessageType = Platform.select({
-    ios: _MessageType,
-    android: _MessageType,
-    harmony: _MessageType_OH
-});
 
 // 消息状态
 export const MessageStatus = {

--- a/src/native/APNs.js
+++ b/src/native/APNs.js
@@ -1,7 +1,18 @@
 import { NativeModules, Platform } from 'react-native';
 import NativeUtil from './native';
 
-const APNs = NativeModules.APNs;
+const APNs = Platform.select({
+    ios: NativeModules.APNs,
+    android: NativeModules.APNs,
+    harmony: {
+        getPushOptionsFromServer() {},
+        setApnsNickname() {},
+        setApnsDisplayStyle() {},
+        setIgnoreGroupPush() {},
+        getIgnoreGroupPush() {},
+        setNoDisturbStatus() {},
+    }
+});
 const isIos = Platform.OS === 'ios';
 
 /**
@@ -37,10 +48,10 @@ export const setIgnoreGroupPush = (groupId, groupType, ignore) => NativeUtil(APN
 });
 
 /**
- * 判断是否开启勿扰   
+ * 判断是否开启勿扰
  * @param {string} groupId 会话 ID
  * @param {string} groupType 会话类型：singleChat（单聊）、groupChat（群聊）和 chatRoom（聊天室）。
- * @returns {boolean} isIgnored 
+ * @returns {boolean} isIgnored
  */
 export const getIgnoreGroupPush = (groupId) => NativeUtil(APNs.getIgnoreGroupPush, { groupId, groupType });
 

--- a/src/native/APNs.js
+++ b/src/native/APNs.js
@@ -1,17 +1,11 @@
 import { NativeModules, Platform } from 'react-native';
 import NativeUtil from './native';
+import { RTNChat } from "../../harmony";
 
 const APNs = Platform.select({
     ios: NativeModules.APNs,
     android: NativeModules.APNs,
-    harmony: {
-        getPushOptionsFromServer() {},
-        setApnsNickname() {},
-        setApnsDisplayStyle() {},
-        setIgnoreGroupPush() {},
-        getIgnoreGroupPush() {},
-        setNoDisturbStatus() {},
-    }
+    harmony: RTNChat
 });
 const isIos = Platform.OS === 'ios';
 

--- a/src/native/ChatManager.js
+++ b/src/native/ChatManager.js
@@ -3,7 +3,24 @@ import NativeUtil from './native';
 import { ChatType, MessageType, MessageDirection } from '../constant/IMConstant';
 import { ObjectUtil } from 'react-native-hecom-common';
 
-const ChatManager = NativeModules.ChatManager;
+const ChatManager = Platform.select({
+    ios: NativeModules.ChatManager,
+    android: NativeModules.ChatManager,
+    harmony: {
+        getConversation() {},
+        getAllConversations() {},
+        deleteConversation() {},
+        loadMessages() {},
+        fetchHistoryMessagesFromServer() {},
+        deleteMessage() {},
+        recallMessage() {},
+        sendMessage() {},
+        insertMessage() {},
+        markAllMessagesAsRead() {},
+        deleteAllMessages() {},
+        updateMessageExt() {},
+    }
+});
 
 /**
  * 获取单个会话。

--- a/src/native/ChatManager.js
+++ b/src/native/ChatManager.js
@@ -8,7 +8,7 @@ const ChatManager = Platform.select({
     android: NativeModules.ChatManager,
     harmony: {
         getConversation() {},
-        getAllConversations() {},
+        async getAllConversations() {return []},
         deleteConversation() {},
         loadMessages() {},
         fetchHistoryMessagesFromServer() {},

--- a/src/native/ChatManager.js
+++ b/src/native/ChatManager.js
@@ -2,24 +2,12 @@ import { NativeModules } from 'react-native';
 import NativeUtil from './native';
 import { ChatType, MessageType, MessageDirection } from '../constant/IMConstant';
 import { ObjectUtil } from 'react-native-hecom-common';
+import { RTNChat } from "../../harmony";
 
 const ChatManager = Platform.select({
     ios: NativeModules.ChatManager,
     android: NativeModules.ChatManager,
-    harmony: {
-        getConversation() {},
-        async getAllConversations() {return []},
-        deleteConversation() {},
-        loadMessages() {},
-        fetchHistoryMessagesFromServer() {},
-        deleteMessage() {},
-        recallMessage() {},
-        sendMessage() {},
-        insertMessage() {},
-        markAllMessagesAsRead() {},
-        deleteAllMessages() {},
-        updateMessageExt() {},
-    }
+    harmony: RTNChat
 });
 
 /**

--- a/src/native/Client.js
+++ b/src/native/Client.js
@@ -33,7 +33,7 @@ const Client = Platform.select({
         isLoggedIn(){
             return RTNChat.isLoggedIn();
         },
-        fetchToken(props){{
+        fetchToken(props){
             /**TODO: 待确认是否需要返回promise，环信的鸿蒙SDK目前不支持*/
             return Promise.reject(new Error('鸿蒙目前不支持，请联系管理员！'));
         }

--- a/src/native/Client.js
+++ b/src/native/Client.js
@@ -1,7 +1,23 @@
 import { NativeModules, Platform } from 'react-native';
 import NativeUtil from './native';
 
-const Client = NativeModules.Client;
+const Client = Platform.select({
+    ios: NativeModules.Client,
+    android: NativeModules.Client,
+    harmony: {
+        init(){
+            return Promise.resolve();
+        },
+        notifyJSDidLoad(){},
+        registerUser(){},
+        login(){},
+        kickAllDevices(){},
+        logout(){},
+        isConnected(){},
+        isLoggedIn(){},
+        fetchToken(){}
+    }
+});
 const isIos = Platform.OS === 'ios';
 
 /**

--- a/src/native/Client.js
+++ b/src/native/Client.js
@@ -5,38 +5,9 @@ import { RTNChat } from "../../harmony";
 const Client = Platform.select({
     ios: NativeModules.Client,
     android: NativeModules.Client,
-    harmony: {
-        init(props){
-            return RTNChat.init(props);
-        },
-        notifyJSDidLoad(){
-            /**TODO: 待确认是否需要返回promise*/
-            return Promise.resolve();
-        },
-        registerUser(){
-            return Promise.reject(new Error('鸿蒙目前不支持，请联系管理员进行用户注册！'));
-        },
-        login(props){
-            return RTNChat.login(props);
-        },
-        kickAllDevices(){
-            /**TODO: 待确认是否需要返回promise，环信的鸿蒙SDK目前不支持*/
-            return Promise.reject(new Error('鸿蒙目前不支持，请联系管理员！'));
-        },
-        logout(){
-            return RTNChat.logout();
-        },
-        isConnected(){
-            // 鸿蒙的SDK没有实现isConnected，直接调用isLoggedIn
-            return RTNChat.isLoggedIn();
-        },
-        isLoggedIn(){
-            return RTNChat.isLoggedIn();
-        },
-        fetchToken(props){
-            /**TODO: 待确认是否需要返回promise，环信的鸿蒙SDK目前不支持*/
-            return Promise.reject(new Error('鸿蒙目前不支持，请联系管理员！'));
-        }
+    harmony: RTNChat,
+    aaa: {
+        
     }
 });
 const isIos = Platform.OS === 'ios';

--- a/src/native/Client.js
+++ b/src/native/Client.js
@@ -1,12 +1,13 @@
 import { NativeModules, Platform } from 'react-native';
 import NativeUtil from './native';
+import { RTNChat } from "../../harmony";
 
 const Client = Platform.select({
     ios: NativeModules.Client,
     android: NativeModules.Client,
     harmony: {
-        init(){
-            return Promise.resolve();
+        init(props){
+            return RTNChat.init(props);
         },
         notifyJSDidLoad(){
             return Promise.resolve();

--- a/src/native/Client.js
+++ b/src/native/Client.js
@@ -10,11 +10,14 @@ const Client = Platform.select({
             return RTNChat.init(props);
         },
         notifyJSDidLoad(){
+            /**TODO: 待确认是否需要返回promise*/
             return Promise.resolve();
         },
-        registerUser(){},
-        login(){
-            return Promise.resolve();
+        registerUser(){
+            return Promise.reject(new Error('请联系管理员进行用户注册！'));
+        },
+        login(props){
+            return RTNChat.login(props);
         },
         kickAllDevices(){},
         logout(){

--- a/src/native/Client.js
+++ b/src/native/Client.js
@@ -14,22 +14,29 @@ const Client = Platform.select({
             return Promise.resolve();
         },
         registerUser(){
-            return Promise.reject(new Error('请联系管理员进行用户注册！'));
+            return Promise.reject(new Error('鸿蒙目前不支持，请联系管理员进行用户注册！'));
         },
         login(props){
             return RTNChat.login(props);
         },
-        kickAllDevices(){},
+        kickAllDevices(){
+            /**TODO: 待确认是否需要返回promise，环信的鸿蒙SDK目前不支持*/
+            return Promise.reject(new Error('鸿蒙目前不支持，请联系管理员！'));
+        },
         logout(){
-            return Promise.resolve();
+            return RTNChat.logout();
         },
         isConnected(){
-            return Promise.resolve();
+            // 鸿蒙的SDK没有实现isConnected，直接调用isLoggedIn
+            return RTNChat.isLoggedIn();
         },
         isLoggedIn(){
-            return Promise.resolve();
+            return RTNChat.isLoggedIn();
         },
-        fetchToken(){}
+        fetchToken(props){{
+            /**TODO: 待确认是否需要返回promise，环信的鸿蒙SDK目前不支持*/
+            return Promise.reject(new Error('鸿蒙目前不支持，请联系管理员！'));
+        }
     }
 });
 const isIos = Platform.OS === 'ios';

--- a/src/native/Client.js
+++ b/src/native/Client.js
@@ -8,13 +8,23 @@ const Client = Platform.select({
         init(){
             return Promise.resolve();
         },
-        notifyJSDidLoad(){},
+        notifyJSDidLoad(){
+            return Promise.resolve();
+        },
         registerUser(){},
-        login(){},
+        login(){
+            return Promise.resolve();
+        },
         kickAllDevices(){},
-        logout(){},
-        isConnected(){},
-        isLoggedIn(){},
+        logout(){
+            return Promise.resolve();
+        },
+        isConnected(){
+            return Promise.resolve();
+        },
+        isLoggedIn(){
+            return Promise.resolve();
+        },
         fetchToken(){}
     }
 });

--- a/src/native/GroupManager.js
+++ b/src/native/GroupManager.js
@@ -1,23 +1,11 @@
 import { NativeModules, Platform } from 'react-native';
 import NativeUtil from './native';
+import { RTNChat } from "../../harmony";
 
 const GroupManager = Platform.select({
     ios: NativeModules.GroupManager,
     android: NativeModules.GroupManager,
-    harmony: {
-        createGroup() {},
-        getJoinedGroups() {},
-        getGroupMemberList() {},
-        getGroupSpecification() {},
-        addOccupants() {},
-        removeOccupants() {},
-        changeGroupSubject() {},
-        leaveGroup() {},
-        destroyGroup() {},
-        updateGroupExt() {},
-        changeGroupDescription() {},
-        updateGroupOwner() {}
-    }
+    harmony: RTNChat
 });
 const isAndroid = Platform.OS === 'android';
 

--- a/src/native/GroupManager.js
+++ b/src/native/GroupManager.js
@@ -8,6 +8,7 @@ const GroupManager = Platform.select({
     harmony: RTNChat
 });
 const isAndroid = Platform.OS === 'android';
+const isIos = Platform.OS === 'ios';
 
 /**
  * 创建群组。
@@ -82,7 +83,7 @@ export const destroyGroup = (groupId) =>
  * @param ext 附加内容
  */
 export const updateGroupExt = (groupId, ext) =>
-    NativeUtil(GroupManager.updateGroupExt,  isAndroid ? {groupId, ext: JSON.stringify(ext)} : {groupId, ext});
+    NativeUtil(GroupManager.updateGroupExt,  isIos ? {groupId, ext} : {groupId, ext: JSON.stringify(ext)});
 
 /**
  * 修改群描述

--- a/src/native/GroupManager.js
+++ b/src/native/GroupManager.js
@@ -1,7 +1,24 @@
 import { NativeModules, Platform } from 'react-native';
 import NativeUtil from './native';
 
-const GroupManager = NativeModules.GroupManager;
+const GroupManager = Platform.select({
+    ios: NativeModules.GroupManager,
+    android: NativeModules.GroupManager,
+    harmony: {
+        createGroup() {},
+        getJoinedGroups() {},
+        getGroupMemberList() {},
+        getGroupSpecification() {},
+        addOccupants() {},
+        removeOccupants() {},
+        changeGroupSubject() {},
+        leaveGroup() {},
+        destroyGroup() {},
+        updateGroupExt() {},
+        changeGroupDescription() {},
+        updateGroupOwner() {}
+    }
+});
 const isAndroid = Platform.OS === 'android';
 
 /**


### PR DESCRIPTION
将 harmony 分支的环信鸿蒙适配（harmony TurboModule spec + src/native 四文件 Platform.select 分发）收编进 master。

⚠️ 已知缺陷：87df5cc 的 src/native/ChatManager.js 仅 import 了 { NativeModules }，新增的 Platform.select 缺失 Platform import，任何平台加载即抛 ReferenceError（RNModules 主仓 jest 实测复现）。建议合并前在本分支补一行 import 后再合入。

关联主仓技术演进: https://devcloud.cn-north-4.huaweicloud.com/projectman/scrum/ea9762777b694cbe8b099d7f6acb453c/task/detail/71133114